### PR TITLE
Add label support

### DIFF
--- a/addon/components/prismic/element.js
+++ b/addon/components/prismic/element.js
@@ -18,6 +18,7 @@ const TAGS = Object.freeze({
   paragraph: 'p',
   preformatted: 'pre',
   strong: 'strong',
+  label: 'label',
 });
 
 export default class PrismicElementComponent extends Component {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -32,6 +32,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-beta',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
@@ -40,6 +41,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),

--- a/tests/integration/components/prismic/element-test.js
+++ b/tests/integration/components/prismic/element-test.js
@@ -171,6 +171,22 @@ module('Integration | Component | prismic/element', function (hooks) {
         '<strong>Qonto The all-in-one business account</strong>'
       );
     });
+
+    test('label', async function (assert) {
+      this.node = {
+        type: 'label',
+        element: {
+          type: 'label',
+          text: 'Qonto The all-in-one business account',
+          spans: [],
+        },
+      };
+      await render(hbs`<Prismic::Element @node={{this.node}} />`);
+      assert.equal(
+        cleanHtml(this),
+        '<label>Qonto The all-in-one business account</label>'
+      );
+    });
   });
 
   module('complex combinations', function () {


### PR DESCRIPTION
Add support the `label` node type.

```json
{
  "type": "label",
  "element": {
    "type": "label",
    "text": "Qonto The all-in-one business account",
    "spans": [],
  },
}
```

Will render:

```html
<label>Qonto The all-in-one business account</label>
```

Fixes: https://github.com/qonto/ember-prismic-dom/issues/5