### PR TITLE
Drop Node.js 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '14.x'
+  NODE_VERSION: ['16.x', '18.x']
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
       - run: yarn install


### PR DESCRIPTION
In this PR we are dropping Node.js 14 support.

We are also adding support for Node.js 18, which is the latest LTS.