### PR TITLE
Use assert.strictEqual instead of assert.equal

### DIFF
--- a/tests/integration/components/prismic/dom-test.js
+++ b/tests/integration/components/prismic/dom-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | prismic/dom', function (hooks) {
   module('single elements', function () {
     test('renders string', async function (assert) {
       await render(hbs`<Prismic::Dom @nodes='some text' />`);
-      assert.equal(cleanHtml(this), '<div>some text</div>');
+      assert.strictEqual(cleanHtml(this), '<div>some text</div>');
     });
   });
 
@@ -36,7 +36,7 @@ module('Integration | Component | prismic/dom', function (hooks) {
       await render(
         hbs`<Prismic::Dom @nodes={{this.nodes}} @hyperlink='hyperlink'/>`
       );
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<div><p>A <a href="https://example.org">link</a> to somewhere</p></div>'
       );
@@ -54,14 +54,14 @@ module('Integration | Component | prismic/dom', function (hooks) {
         hbs`<Prismic::Dom @nodes={{this.nodes}} @group-list-item='group-list-item' @list-item={{this.listItem}}/>`
       );
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<div><ul><li>one</li><li>two</li>elephant</ul></div>'
       );
 
       this.set('listItem', 'list-item');
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<div><ul><li>one bananna</li><li>two bananna</li>elephant</ul></div>'
       );
@@ -77,7 +77,7 @@ module('Integration | Component | prismic/dom', function (hooks) {
 
       await render(hbs`<Prismic::Dom @nodes={{this.nodes}} />`);
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<div><ol><li>one</li><li>two</li></ol></div>'
       );
@@ -97,7 +97,7 @@ module('Integration | Component | prismic/dom', function (hooks) {
 
       await render(hbs`<Prismic::Dom @nodes={{this.nodes}} />`);
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<div><p>This is some text with <strong>overla</strong><em><strong>pp</strong>ings</em> spans and here</p></div>'
       );
@@ -123,7 +123,7 @@ module('Integration | Component | prismic/dom', function (hooks) {
 
       await render(hbs`<Prismic::Dom @nodes={{this.nodes}} />`);
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<div><p><em>A </em><a href="https://example.org" rel="noreferrer noopener" target="_blank"><em>li<strong></strong></em><strong>nk</strong></a><strong> wi</strong>th overlap</p></div>'
       );

--- a/tests/integration/components/prismic/element-test.js
+++ b/tests/integration/components/prismic/element-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | prismic/element', function (hooks) {
       await render(
         hbs`<Prismic::Element @node={{this.node}} @onUnknownTag={{this.onUnknownTag}} />`
       );
-      assert.equal(cleanHtml(this), '<!---->', 'not displayed');
+      assert.strictEqual(cleanHtml(this), '<!---->', 'not displayed');
     });
 
     test('em', async function (assert) {
@@ -39,7 +39,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<em>Qonto The all-in-one business account</em>'
       );
@@ -55,7 +55,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<h1>Qonto The all-in-one business account</h1>'
       );
@@ -85,7 +85,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         text: 'example',
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<a href="https://example.org" rel="noreferrer noopener" target="_blank">example</a>'
       );
@@ -105,7 +105,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<img alt="Qonto The all-in-one business account" copyright="qonto" src="/assets/img/connect/slack.png" width="500" height="400">'
       );
@@ -121,7 +121,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<p>Qonto The all-in-one business account</p>'
       );
@@ -137,7 +137,10 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(cleanHtml(this), 'Qonto The all-in-one business account');
+      assert.strictEqual(
+        cleanHtml(this),
+        'Qonto The all-in-one business account'
+      );
     });
 
     test('preformatted', async function (assert) {
@@ -150,7 +153,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<pre>Qonto The all-in-one business account</pre>'
       );
@@ -166,7 +169,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<strong>Qonto The all-in-one business account</strong>'
       );
@@ -182,7 +185,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         },
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<label>Qonto The all-in-one business account</label>'
       );
@@ -214,7 +217,7 @@ module('Integration | Component | prismic/element', function (hooks) {
         ],
       };
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
-      assert.equal(cleanHtml(this), '<ul><li>one</li><li>two</li></ul>');
+      assert.strictEqual(cleanHtml(this), '<ul><li>one</li><li>two</li></ul>');
     });
 
     test('it renders', async function (assert) {
@@ -311,7 +314,7 @@ module('Integration | Component | prismic/element', function (hooks) {
 
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<p>This is some text with <strong>overla</strong><em><strong>pp</strong>ings</em> spans and here</p>'
       );
@@ -447,7 +450,7 @@ module('Integration | Component | prismic/element', function (hooks) {
 
       await render(hbs`<Prismic::Element @node={{this.node}} />`);
 
-      assert.equal(
+      assert.strictEqual(
         cleanHtml(this),
         '<p><em>A </em><a href="https://example.org" rel="noreferrer noopener" target="_blank"><em>li<strong></strong></em><strong>nk</strong></a><strong> wi</strong>th overlap</p>'
       );

--- a/tests/integration/components/prismic/image-test.js
+++ b/tests/integration/components/prismic/image-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | prismic/image', function (hooks) {
       },
     };
     await render(hbs`<Prismic::Image @node={{this.node}} />`);
-    assert.equal(
+    assert.strictEqual(
       cleanHtml(this),
       '<img alt="Qonto The all-in-one business account" copyright="qonto" src="/assets/img/connect/slack.png" width="500" height="400">'
     );
@@ -44,7 +44,7 @@ module('Integration | Component | prismic/image', function (hooks) {
       },
     };
     await render(hbs`<Prismic::Image @node={{this.node}} />`);
-    assert.equal(
+    assert.strictEqual(
       cleanHtml(this),
       '<a href="https://example.org" target="_blank" rel="noreferrer noopener"><img alt="Qonto The all-in-one business account" copyright="qonto" src="/assets/img/connect/slack.png" width="500" height="400"></a>'
     );
@@ -66,7 +66,7 @@ module('Integration | Component | prismic/image', function (hooks) {
       },
     };
     await render(hbs`<Prismic::Image @node={{this.node}} />`);
-    assert.equal(
+    assert.strictEqual(
       cleanHtml(this),
       '<a href="https://example.org" target="_top" rel="noreferrer noopener"><img alt="Qonto The all-in-one business account" copyright="qonto" src="/assets/img/connect/slack.png" width="500" height="400"></a>'
     );


### PR DESCRIPTION
`equal` deprecated method is replaced by `strictEqual` in tests