### PR TITLE
Convert to v2 addon format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v2.1.0 (2022-09-14)
+
+#### :rocket: Enhancement
+
+Convert to v2 addon format
 
 ## v2.0.0 (2022-09-14)
 


### PR DESCRIPTION
### Description

The addon is converted to latest v2 format. Plus, `pnpm` is used instead of `npm` to manage the project.

https://github.com/NullVoxPopuli/ember-addon-migrator codemod is used to update files structure. 

Resolves https://github.com/qonto/ember-prismic-dom/issues/14

### Changes
* Addon is built in v2 format

### Checklist 
- [ ] Run codemode
- [ ] Build & lint & test locally
- [ ] Fix GitHub CI
- [ ] Backport metadata to addon's `package.json`
- [ ] Backport files:
  - [ ] README.md
  - [ ] CHANGELOG.md
  - [ ] LICENSE.md
  - [ ] CONTRIBUTING.md
- [ ] Backport .npmignore to the addon
- [ ] Restore dependabot config
- [ ] Configure release procedure