### PR TITLE
wrap unsafe component invocation with ensure-safe-component

### DIFF
--- a/ember-prismic-dom/src/components/prismic/element.hbs
+++ b/ember-prismic-dom/src/components/prismic/element.hbs
@@ -1,5 +1,5 @@
 {{~#if this.isCustom~}}
-  {{~#component this.componentName node=@node~}}
+  {{~#component (ensure-safe-component this.componentName) node=@node~}}
     <Prismic::Children
       @componentNames={{@componentNames}}
       @node={{@node}}


### PR DESCRIPTION
Following [these guidelines](https://github.com/embroider-build/embroider/blob/main/docs/replacing-component-helper.md#when-you-need-to-curry-arguments-onto-a-component) this MR adds the ensure-safe-component to a dynamic component invocation. 