### PR TITLE
Drop node v14 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Easy [Prismic](https://prismic.io/) rendering in [Ember.js](https://emberjs.com)
 
 - Ember.js v4.4 or above
 - Ember CLI v4.4 or above
-- Node.js v14 or above
+- Node.js v16 or above
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-app"
   ],
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -78,7 +78,7 @@
     "release-it-lerna-changelog": "^5.0.0"
   },
   "engines": {
-    "node": "14.* || 16.* || >= 18"
+    "node": "16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
# Description

In this PR, `ember-prismic-dom` gets no more support for node v14. Node v16 becomes the earliest supported version.

# Why?

Node v14 has entered maintenance mode and it has no more active and security support. See https://endoflife.date/nodejs for more info.

Moreover, the CI Node version has already been upgraded in https://github.com/qonto/ember-prismic-dom/pull/24 when migrating from `yarn` to `pnpm`.