### PR TITLE
Remove double node installation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.6.0
+          node-version: "${{ env.NODE_VERSION }}"
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
@@ -72,14 +69,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.6.0
+          node-version: "${{ env.NODE_VERSION }}"
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Tests
@@ -99,13 +93,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.6.0
+          node-version: "${{ env.NODE_VERSION }}"
           no-lockfile: true
       - name: Install dependencies
         run: pnpm install --no-lockfile
@@ -141,14 +133,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "${{ env.NODE_VERSION }}"
       - name: Install pnpm
         uses: NullVoxPopuli/action-setup-pnpm@v2
         with:
           pnpm-version: 8.6.0
+          node-version: "${{ env.NODE_VERSION }}"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run tests


### PR DESCRIPTION
`NullVoxPopuli/action-setup-pnpm` already handles the node setup. So we were running `actions/setup-node` twice.