### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+    versioning-strategy: increase


### PR DESCRIPTION
This PR adds explicit dependabot configuration as in https://github.com/qonto/ember-amount-input/blob/master/.github/dependabot.yml.