### PR TITLE
chore: remove documentation for missing `pnpm test:watch` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@
 
 - `cd test-app`
 - `pnpm test` – Runs the test suite on the current Ember version
-- `pnpm test:watch` – Runs the test suite in "watch mode"
 
 ## Running the test application
 


### PR DESCRIPTION
Currently there is no `pnpm test:watch` command specified in `package.json` and we don’t plan to add it, therefore we remove this line from the contributing documentation.

Tests can still be run from the CLI via `pnpm test`, or in “watch mode” by booting the test application and visiting `http://localhost:4200/tests`.