### PR TITLE
chore: prettify templates and remove unnecessary files

### DIFF
--- a/ember-prismic-dom/src/components/prismic/children.hbs
+++ b/ember-prismic-dom/src/components/prismic/children.hbs
@@ -2,7 +2,8 @@
   <Prismic::Element
     @componentNames={{@componentNames}}
     @node={{child}}
-    @onUnknownTag={{@onUnknownTag}} />
+    @onUnknownTag={{@onUnknownTag}}
+  />
 {{~else~}}
   {{~@node.element.text~}}
 {{~/each~}}

--- a/ember-prismic-dom/src/components/prismic/element.hbs
+++ b/ember-prismic-dom/src/components/prismic/element.hbs
@@ -6,30 +6,30 @@
       @onUnknownTag={{@onUnknownTag}}
     />
   {{~/component~}}
-{{~else if (eq @node.type "image")~}}
+{{~else if (eq @node.type 'image')~}}
   <Prismic::Image @node={{@node}} />
-{{~else if (eq @node.type "span")~}}
+{{~else if (eq @node.type 'span')~}}
   <Prismic::Children
     @componentNames={{@componentNames}}
     @node={{@node}}
     @onUnknownTag={{@onUnknownTag}}
   />
-{{~else if (eq @node.type "hyperlink")~}}
+{{~else if (eq @node.type 'hyperlink')~}}
   <a
     href={{@node.element.data.url}}
-    rel="noreferrer noopener"
+    rel='noreferrer noopener'
     target={{this.target}}
   ><Prismic::Children
-    @componentNames={{@componentNames}}
-    @node={{@node}}
-    @onUnknownTag={{@onUnknownTag}}
-  /></a>
-{{~else~}}
-  {{~#let (element this.tagName) as |Tag|~}}
-    <Tag><Prismic::Children
       @componentNames={{@componentNames}}
       @node={{@node}}
       @onUnknownTag={{@onUnknownTag}}
-    /></Tag>
+    /></a>
+{{~else~}}
+  {{~#let (element this.tagName) as |Tag|~}}
+    <Tag><Prismic::Children
+        @componentNames={{@componentNames}}
+        @node={{@node}}
+        @onUnknownTag={{@onUnknownTag}}
+      /></Tag>
   {{~/let~}}
 {{~/if~}}

--- a/ember-prismic-dom/src/components/prismic/image.hbs
+++ b/ember-prismic-dom/src/components/prismic/image.hbs
@@ -1,15 +1,15 @@
 {{~#if @node.element.linkUrl~}}
   <a
     href={{@node.element.linkUrl}}
-    target={{if @node.element.linkTarget @node.element.linkTarget "_blank"}}
-    rel="noreferrer noopener"
+    target={{if @node.element.linkTarget @node.element.linkTarget '_blank'}}
+    rel='noreferrer noopener'
   ><img
       alt={{@node.element.alt}}
       copyright={{@node.element.copyright}}
       src={{@node.element.url}}
       width={{@node.element.width}}
       height={{@node.element.height}}
-  /></a>
+    /></a>
 {{~else~}}
   <img
     alt={{@node.element.alt}}


### PR DESCRIPTION
With the help of Prettier, we format the addon’s templates (quotes and indentation) and remove a couple `.gitkeep` files that are not needed as placeholders since the directory contains other source files.