### PR TITLE
refactor: use variable assignment and bound value instead of {{component}} helper

### DIFF
--- a/ember-prismic-dom/src/components/prismic/element.hbs
+++ b/ember-prismic-dom/src/components/prismic/element.hbs
@@ -1,11 +1,13 @@
 {{~#if this.isCustom~}}
-  {{~#component (ensure-safe-component this.componentName) node=@node~}}
-    <Prismic::Children
-      @componentNames={{@componentNames}}
-      @node={{@node}}
-      @onUnknownTag={{@onUnknownTag}}
-    />
-  {{~/component~}}
+  {{~#let (ensure-safe-component this.componentName) as |CustomComponent|~}}
+    {{~#CustomComponent node=@node~}}
+      <Prismic::Children
+        @componentNames={{@componentNames}}
+        @node={{@node}}
+        @onUnknownTag={{@onUnknownTag}}
+      />
+    {{~/CustomComponent~}}
+  {{~/let~}}
 {{~else if (eq @node.type 'image')~}}
   <Prismic::Image @node={{@node}} />
 {{~else if (eq @node.type 'span')~}}


### PR DESCRIPTION
### Description

We move off the component helper to use a variable assignment and use the bound value in `element.hbs`.

### Why?

Our goal is to migrate the addon to TypeScript. We'd like to use Glint. But the component helper will throw a linting error: `The {{component}} helper can't be used directly in block form under Glint. Consider first binding the result to a variable, e.g. '{{#let (component ...) as |...|}}' and then using the bound value.`