### PR TITLE
feat: drop node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: "16.x"
+  NODE_VERSION: "18.x"
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Easy [Prismic](https://prismic.io/) rendering in [Ember.js](https://emberjs.com)
 
 - Ember.js v4.4 or above
 - Ember CLI v4.4 or above
-- Node.js v16 or above
+- Node.js v18 or above
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test-app"
   ],
   "engines": {
-    "node": "16.* || >= 18"
+    "node": ">= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -86,7 +86,7 @@
     "webpack": "^5.89.0"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": ">= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
# Description

In this PR, `ember-prismic-dom` gets no more support for node v16. Node v18 becomes the earliest supported version as it is still active for now.

# Why?

Node v16 has no more active and security support. See https://endoflife.date/nodejs for more info.

The compatibility section of the package in the `README` is updated to inform node v18 or above is supported.