### PR TITLE
chore(ci): add type checking for typescript@5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
         typescript-scenario:
           - typescript@5.0
           - typescript@5.1
+          - typescript@5.2
           - typescript@next
 
     steps:


### PR DESCRIPTION
In this PR, we add a missing job for type checking with TypeScript v5.2. Since by default we use the latest `typescript@5.3.2`.