### PR TITLE
chore: configure commitlint on CI

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,59 @@
+name: commitlint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.5.1
+          run_install: false
+
+      - name: Set ENV variables
+        shell: bash
+        run: |
+          echo "COMMITLINT_CLI_VERSION=$(pnpm show @commitlint/cli version)" >> $GITHUB_ENV
+          echo "COMMITLINT_CONFIG_CONVENTIONAL_VERSION=$(pnpm show @commitlint/config-conventional version)" >> $GITHUB_ENV
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CONVENTIONAL_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install commitlint
+        run: |
+          pnpm install -w @commitlint/cli@$COMMITLINT_CLI_VERSION"
+          pnpm install -w @commitlint/config-conventional@COMMITLINT_CONFIG_CONVENTIONAL_VERSION"
+
+      - name: Validate current commit (last commit) with commitlint
+        if: github.event_name == 'push'
+        run: pnpm commitlint --from HEAD~1 --to HEAD --verbose
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: pnpm commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
With this PR we want to build upon #144 and set up `commitlint` to run on CI when pushing to `main` or doing any kind of activity on a pull request.

This workflow will:
* Check out the repository with all its history
* Set up Node and pnpm
* Install `commitlint` (with cache support)
* Validate last commit and PR commits

To temporarily bypass the commit message check locally, and test it was failing on our CI, we used the `--no-verify` option with `git commit`.