### PR TITLE
chore(dependabot): switch to `weekly` interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
In this PR, we switch from `daily` to `weekly` for the dependabot interval. `daily` interval was first set to test the configuration when it was first introduced.